### PR TITLE
fix: Resolve TypeScript and JSX build errors

### DIFF
--- a/yemi-ogundairo/src/components/sections/Hero.tsx
+++ b/yemi-ogundairo/src/components/sections/Hero.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typed } from 'react-typed'; // Corrected import
+import { ReactTyped } from 'react-typed';
 
 const Hero: React.FC = () => {
   return (
@@ -30,7 +30,7 @@ const Hero: React.FC = () => {
           data-aos="fade-up"
           data-aos-delay="400"
         >
-          <Typed
+          <ReactTyped
             strings={[
               "A Product Designer",
               "A Frontend Developer",

--- a/yemi-ogundairo/src/components/sections/Portfolio.tsx
+++ b/yemi-ogundairo/src/components/sections/Portfolio.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
-import { projectsData, portfolioCategories, Project, ProjectCategory } from '../../data/portfolioData';
+import { projectsData, portfolioCategories } from '../../data/portfolioData';
+import type { Project, ProjectCategory } from '../../data/portfolioData';
 import PortfolioCard from './PortfolioCard';
 import ProjectModal from './ProjectModal';
 
@@ -55,12 +56,12 @@ const Portfolio: React.FC = () => {
         {/* Portfolio Grid */}
         {filteredProjects.length > 0 ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-            {filteredProjects.map((project, index) => (
+            {filteredProjects.map((project) => (
               <PortfolioCard
                 key={project.id}
                 project={project}
                 onViewDetails={handleViewDetails}
-                // data-aos-delay can be added here if needed: `${index * 100}`
+                // data-aos-delay can be added here if needed for staggered animation
               />
             ))}
           </div>

--- a/yemi-ogundairo/src/components/sections/PortfolioCard.tsx
+++ b/yemi-ogundairo/src/components/sections/PortfolioCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Project } from '../../data/portfolioData';
+import type { Project } from '../../data/portfolioData';
 
 interface PortfolioCardProps {
   project: Project;

--- a/yemi-ogundairo/src/components/sections/ProjectModal.tsx
+++ b/yemi-ogundairo/src/components/sections/ProjectModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Project } from '../../data/portfolioData'; // Assuming Project type is exported from data
+import type { Project } from '../../data/portfolioData'; // Assuming Project type is exported from data
 
 interface ProjectModalProps {
   project: Project | null;


### PR DESCRIPTION
- Corrects usage of react-typed component in Hero.tsx.
- Updates type imports to use 'import type' where required by verbatimModuleSyntax.
- Removes unused 'index' variable in Portfolio.tsx map function.

These changes address build failures identified in Vercel deployment.