### PR TITLE
fix: Remove postcss.config.js to resolve Tailwind v4 build error

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,0 @@
-export default {
-  plugins: {
-    tailwindcss: {},
-  },
-}


### PR DESCRIPTION
Deletes postcss.config.js as it's not needed when using @tailwindcss/vite plugin with Tailwind CSS v4. This plugin handles the PostCSS setup internally. This change addresses the build failure related to incorrect PostCSS plugin configuration for Tailwind.